### PR TITLE
Update the executable name

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jscs -p google index.js test/test.js && mocha test/test.js"
   },
   "bin": {
-    "tree": "bin/cli.js"
+    "npm-dependency-tree": "bin/cli.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`tree` is conflicting with the popular tree utility. Here's my suggested name: `npm-dependency-tree`.

I think it's easier to remember with if prefixed with npm since only **dependency-tree** is very generic.

see [https://github.com/mrjoelkemp/node-dependency-tree/issues/30](https://github.com/mrjoelkemp/node-dependency-tree/issues/30)